### PR TITLE
feat(api-configuration): configure axios to be used as plugin and retrieve data

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -26,6 +26,7 @@ export default {
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
   plugins: [
+    '~/plugins/API'
   ],
 
   // Auto import components: https://go.nuxtjs.dev/config-components

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,7 +3,12 @@
 </template>
 
 <script>
+import VehiculesAPI from '../services/api/VehiculesAPI';
 export default {
-  name: 'IndexPage'
+  name: 'IndexPage',
+  async mounted() {
+    const vehicules = await VehiculesAPI.fetchVehicules();
+    console.log(vehicules);
+  }
 }
 </script>

--- a/plugins/API.js
+++ b/plugins/API.js
@@ -1,0 +1,5 @@
+import VehiculesAPI from "../services/api/VehiculesAPI";
+
+export default function ({ $axios }) {
+  VehiculesAPI.init($axios);
+}

--- a/services/api/VehiculesAPI.js
+++ b/services/api/VehiculesAPI.js
@@ -1,0 +1,27 @@
+class _VehiculesAPI {
+
+  constructor() {
+    this.baseURL = 'https://gitlab.com/api/v4/snippets/2095016';
+  }
+
+  init(axios) {
+    this.API = axios;
+  }
+
+  /**
+   * Method to fetch a list of vehicules from the provided json file
+   * @returns Promise with an array of vehicules objects
+   */
+  async fetchVehicules(){
+    try {
+      const response = await this.API.$get(`${this.baseURL}/raw`);
+      return Promise.resolve(response);
+    } catch(error) {
+      return Promise.resolve(error);
+    }
+  }
+}
+
+const VehiculesAPI = new _VehiculesAPI();
+
+export default VehiculesAPI;


### PR DESCRIPTION
The aim is to configure axios to be used as plugin and create handlers to retrieve data

- Use axios as plugin and declare it in nuxt.config
- Create VehiculesAPI class to handle all API call regarding vehicules
- Create fetchVehicules method to fetch a list of vehicules

[Level 1 assigment](https://gitlab.com/yescapa-pub/jobs/-/tree/master/vuejs/level1)