### PR TITLE
feat(vehicule-details-layout): create new vehicule details page and layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ $ yarn generate
 - [x] Retrieve data from store
 
 ### **Vehicule details**
-- [ ] Create the details layout
+- [x] Create the details layout
+  - [x] Create the details page
+  - [x] Create the reassurance component
 - [ ] Create the details component
-- [ ] Create the reassurance component
 - [ ] Retrieve data from store

--- a/components/common/Reassurance.vue
+++ b/components/common/Reassurance.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="reassurance border p-4 md:p-8">
+    <h3>Reassurance</h3>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Reassurance',
+}
+</script>

--- a/pages/vehicules/_id.vue
+++ b/pages/vehicules/_id.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="v-container w-full px-4 md:px-8 grid grid-cols-12 gap-4 sm:gap-8">
+    <div class="v-filters col-span-12 sm:col-span-8">
+      <div class="v-details border p-4 md:p-8">
+        <h3>Details</h3>
+      </div>
+    </div>
+    <aside class="col-span-12 sm:col-span-4">
+      <div class="v-booking border p-4 md:p-8 mb-4 md:mb-8">
+        <h3>Booking</h3>
+      </div>
+      <Reassurance />
+    </aside>
+  </div>
+</template>
+
+<script>
+import Reassurance from '~/components/common/Reassurance.vue';
+
+export default {
+  name: 'VehiculeDetailsPage',
+  layout: 'list',
+  components: {
+    Reassurance,
+  }
+}
+</script>
+
+<style>
+
+</style>


### PR DESCRIPTION
The aim is to create a layout and a specific page for the vehicules details to be displayed

- Create a page for vehicule details under pages/vehicules/_id.vue
- Create reassurance component

[Level 3 assigment](https://gitlab.com/yescapa-pub/jobs/-/tree/master/vuejs/level3)