### PR TITLE
fix(details-image-spacing): remove details image padding

### DIFF
--- a/pages/vehicules/_id.vue
+++ b/pages/vehicules/_id.vue
@@ -2,7 +2,7 @@
   <div class="v-container w-full px-4 md:px-8 grid grid-cols-12 gap-4 sm:gap-8">
     <!-- Vehicule details -->
     <div class="col-span-12 sm:col-span-8">
-      <div class="v-details px-0 pb-4 md:px-8 md:pb-8">
+      <div class="v-details px-0 pb-4 md:pb-8">
         <!-- Vehicule image -->
         <img
           :src="picture"


### PR DESCRIPTION
The aim is to fix the space around the vehicule details image

* Remove the image container padding on left and right